### PR TITLE
Fix to abort binary file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "glob-cache-warmer",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.0.1",
+      "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
         "consola": "^2.15.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "glob-cache-warmer",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "Simple web crawler for creation CDN cache after deploy.",
   "engines": {
     "node": ">=14.x"

--- a/src/commands/default.ts
+++ b/src/commands/default.ts
@@ -60,6 +60,17 @@ export const defaultCommand = {
     await Promise.all(files.map(async file => {
       const page = await browser.newPage()
       const response = await page.goto(url + file)
+        .catch(e => {
+          logger.warn('ABORT:', {
+            url: `${url}${file}`,
+            message: e.message,
+          })
+        })
+
+      if (!response) {
+        return
+      }
+
       const metrics = await page.metrics()
       const headers = response.headers()
 


### PR DESCRIPTION
puppeteer がバイナリ (というか chrome で表示できず download 扱いになるやつ) について対応してない。

https://github.com/puppeteer/puppeteer/issues/299

いまのとこ無視するか他のライブラリ使うしかない、一旦無視した。

